### PR TITLE
fix: actually respect noWizard option

### DIFF
--- a/src/schematics/webdriverio/index.ts
+++ b/src/schematics/webdriverio/index.ts
@@ -33,7 +33,7 @@ export function webdriverioSchematics(_options: SchematicsOptions): Rule {
         return chain([
             updateDependencies(_options),
             _options.removeProtractor ? removeFiles() : noop(),
-            _options.noWizard ? runWizard(_options) : noop(),
+            !_options.noWizard ? runWizard(_options) : noop(),
             !_options.noBuilder ? modifyAngularJson(_options) : noop(),
         ])(tree, _context);
     };

--- a/src/schematics/webdriverio/index.ts
+++ b/src/schematics/webdriverio/index.ts
@@ -33,7 +33,7 @@ export function webdriverioSchematics(_options: SchematicsOptions): Rule {
         return chain([
             updateDependencies(_options),
             _options.removeProtractor ? removeFiles() : noop(),
-            runWizard(_options),
+            _options.noWizard ? runWizard(_options) : noop(),
             !_options.noBuilder ? modifyAngularJson(_options) : noop(),
         ])(tree, _context);
     };


### PR DESCRIPTION
Currently the wizard runs all the time, no matter if the `--noWizard` option is supplied